### PR TITLE
[TASK] Testing with php 8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php: [ '7.2', '7.3', '7.4' ]
+        php: [ '7.2', '7.3', '7.4', '8.0' ]
         minMax: [ 'composerInstallMin', 'composerInstallMax' ]
     steps:
       - name: Checkout

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -52,6 +52,14 @@ services:
         if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
           set -x
         fi
+        if [ ${PHP_VERSION} == "8.0" ]; then
+          composer req --dev typo3/cms-core:"dev-master" \
+            typo3/cms-backend:"dev-master" \
+            typo3/cms-frontend:"dev-master" \
+            typo3/cms-extbase:"dev-master" \
+            typo3/cms-fluid:"dev-master" \
+            typo3/cms-recordlist:"dev-master"
+        fi
         composer config --unset platform.php;
         composer update --no-progress --no-interaction;
         composer dumpautoload;
@@ -70,6 +78,14 @@ services:
       /bin/sh -c "
         if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
           set -x
+        fi
+        if [ ${PHP_VERSION} == "8.0" ]; then
+          composer req --dev typo3/cms-core:"dev-master" \
+            typo3/cms-backend:"dev-master" \
+            typo3/cms-frontend:"dev-master" \
+            typo3/cms-extbase:"dev-master" \
+            typo3/cms-fluid:"dev-master" \
+            typo3/cms-recordlist:"dev-master"
         fi
         composer config platform.php ${PHP_VERSION}.0;
         composer update --prefer-lowest --no-progress --no-interaction;


### PR DESCRIPTION
Since there is no released core with php 8 compat yet,
we need to hack the testing docker-compose.yml slightly
to allow core dev-master packages for this run. This
can be dropped later again, but allows us early php 8
testing for this extension without spoiling normal
composer requirements.